### PR TITLE
Use wrapper for gocryptfs and CryFS

### DIFF
--- a/build-aux/cryfs-unmount-wrapper.sh
+++ b/build-aux/cryfs-unmount-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec flatpak-spawn --host cryfs-unmount "$@"

--- a/build-aux/cryfs-wrapper.sh
+++ b/build-aux/cryfs-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$#" -eq 2 ]; then
+    exec flatpak-spawn --host --env=CRYFS_FRONTEND=noninteractive cryfs "$@"
+else
+    exec flatpak-spawn --host cryfs "$@"
+fi

--- a/build-aux/fusermount-wrapper.sh
+++ b/build-aux/fusermount-wrapper.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# From: https://gitlab.gnome.org/GNOME/gnome-builder/-/blob/main/build-aux/flatpak/fusermount-wrapper.sh
+
+if [ -z "$_FUSE_COMMFD" ]; then
+    FD_ARGS=
+else
+    FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
+fi
+
+if [ -e /proc/self/fd/3 ] && [ 3 != "$_FUSE_COMMFD" ]; then
+    FD_ARGS="$FD_ARGS --forward-fd=3"
+fi
+
+exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 $FD_ARGS fusermount "$@"

--- a/build-aux/gocryptfs-wrapper.sh
+++ b/build-aux/gocryptfs-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec flatpak-spawn --host gocryptfs "$@"

--- a/io.github.mpobaschnig.Vaults.Devel.json
+++ b/io.github.mpobaschnig.Vaults.Devel.json
@@ -29,6 +29,65 @@
     },
     "modules": [
         {
+            "name": "libfuse",
+            "config-opts": [
+                "MOUNT_FUSE_PATH=/app/bin"
+            ],
+            "post-install": [
+                "install fusermount-wrapper.sh /app/bin/fusermount"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz",
+                    "sha256": "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
+                },
+                {
+                    "type": "file",
+                    "path": "build-aux/fusermount-wrapper.sh"
+                }
+            ]
+        },
+        {
+            "name": "cryfs",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install cryfs-wrapper.sh /app/bin/cryfs"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "build-aux/cryfs-wrapper.sh"
+                }
+            ]
+        },
+        {
+            "name": "cryfs-unmount",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install cryfs-unmount-wrapper.sh /app/bin/cryfs-unmount"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "build-aux/cryfs-unmount-wrapper.sh"
+                }
+            ]
+        },
+            {
+            "name": "gocryptfs",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install gocryptfs-wrapper.sh /app/bin/gocryptfs"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "build-aux/gocryptfs-wrapper.sh"
+                }
+            ]
+        },
+        {
             "name": "vaults",
             "buildsystem": "meson",
             "run-tests": true,

--- a/src/backend/cryfs.rs
+++ b/src/backend/cryfs.rs
@@ -24,9 +24,7 @@ use std::process::Command;
 use std::{self, io::Write, process::Stdio};
 
 pub fn is_available() -> Result<bool, BackendError> {
-    let output = Command::new("flatpak-spawn")
-        .arg("--host")
-        .arg("cryfs")
+    let output = Command::new("cryfs")
         .arg("--version")
         .output()?;
 
@@ -39,12 +37,9 @@ pub fn init(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
 }
 
 pub fn open(vault_config: &VaultConfig, password: String) -> Result<(), BackendError> {
-    let mut child = Command::new("flatpak-spawn")
+    let mut child = Command::new("cryfs")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .arg("--host")
-        .arg("--env=CRYFS_FRONTEND=noninteractive")
-        .arg("cryfs")
         .arg(&vault_config.encrypted_data_directory)
         .arg(&vault_config.mount_directory)
         .spawn()?;
@@ -70,10 +65,8 @@ pub fn open(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
 }
 
 pub fn close(vault_config: &VaultConfig) -> Result<(), BackendError> {
-    let child = Command::new("flatpak-spawn")
+    let child = Command::new("cryfs-unmount")
         .stdout(Stdio::piped())
-        .arg("--host")
-        .arg("cryfs-unmount")
         .arg(&vault_config.mount_directory)
         .spawn()?;
 

--- a/src/backend/gocryptfs.rs
+++ b/src/backend/gocryptfs.rs
@@ -24,9 +24,7 @@ use std::process::Command;
 use std::{io::Write, process::Stdio};
 
 pub fn is_available() -> Result<bool, BackendError> {
-    let output = Command::new("flatpak-spawn")
-        .arg("--host")
-        .arg("gocryptfs")
+    let output = Command::new("gocryptfs")
         .arg("--version")
         .output()?;
 
@@ -34,11 +32,9 @@ pub fn is_available() -> Result<bool, BackendError> {
 }
 
 pub fn init(vault_config: &VaultConfig, password: String) -> Result<(), BackendError> {
-    let mut child = Command::new("flatpak-spawn")
+    let mut child = Command::new("gocryptfs")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .arg("--host")
-        .arg("gocryptfs")
         .arg("--init")
         .arg("-q")
         .arg("--")
@@ -68,11 +64,9 @@ pub fn init(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
 }
 
 pub fn open(vault_config: &VaultConfig, password: String) -> Result<(), BackendError> {
-    let mut child = Command::new("flatpak-spawn")
+    let mut child = Command::new("gocryptfs")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .arg("--host")
-        .arg("gocryptfs")
         .arg("-q")
         .arg("--")
         .arg(&vault_config.encrypted_data_directory)
@@ -100,10 +94,8 @@ pub fn open(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
 }
 
 pub fn close(vault_config: &VaultConfig) -> Result<(), BackendError> {
-    let child = Command::new("flatpak-spawn")
+    let child = Command::new("fusermount")
         .stdout(Stdio::piped())
-        .arg("--host")
-        .arg("fusermount")
         .arg("-u")
         .arg(&vault_config.mount_directory)
         .spawn()?;


### PR DESCRIPTION
Use wrappers for gocryptfs and CryFS commands until we have dependencies included in flatpak. This allows us to build and run it without flatpak.

Closes: https://github.com/mpobaschnig/Vaults/issues/6