### PR TITLE
vault: Manually track state for hidden mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "partition-identity"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "pest"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-mounts"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d652f8435d0ab70bf4f3590a6a851d59604831a458086541b95238cc51ffcf2"
+dependencies = [
+ "partition-identity",
 ]
 
 [[package]]
@@ -941,6 +959,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty_env_logger",
+ "proc-mounts",
  "quick-error 2.0.1",
  "serde",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ toml = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 adw = { version = "0.2", package = "libadwaita", features = ["v1_2"] }
 gtk = { version = "0.5", package = "gtk4", features = ["v4_8"]}
+proc-mounts = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod ui;
 
 #[macro_use]
 extern crate quick_error;
+extern crate proc_mounts;
 extern crate serde;
 extern crate toml;
 

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -220,3 +220,68 @@ impl Vault {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_hidden_paths() {
+        let vault = Vault::new(
+            "".to_string(),
+            Backend::Gocryptfs,
+            "".to_string(),
+            "".to_string(),
+        );
+        assert_eq!(vault.is_mount_hidden(), false);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: ".".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), false);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "..".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), false);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "./".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), false);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "./Hidden".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), false);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "tets/.Test".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), true);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "./Test/.Test".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), true);
+
+        vault.set_config(VaultConfig {
+            backend: Backend::Gocryptfs,
+            encrypted_data_directory: "".to_string(),
+            mount_directory: "../.Test".to_string(),
+        });
+        assert_eq!(vault.is_mount_hidden(), true);
+    }
+}


### PR DESCRIPTION
From the first commit:

> Previously, Vaults is relying on gio's VolumeMonitor to monitor "user
> interesting devices and volumes on the computer". As soon as the mounted
> path contains a hidden folder, it's no longer 'user interesting',
> according to the library developers, and thus disappears from the list
> of mounted folders. Consequently, Vaults can't detect if the folder has
> already been mounted or not and won't correctly unmount it as it
> guesses to be unmounted, since there is no entry.
> 
> Fix this by introducing manually tracking of Vaults that have hidden
> mount directories. For that, we use the previously used "proc-mounts"
> crate and look for the Vault within all mounts. However, automatic
> tracking of external unmounting or mounting is missing with this
> approach.
> 
> Closes: https://github.com/mpobaschnig/Vaults/issues/45