### PR TITLE
POTFILES.in: Remove obsolete file references and reorder list for better readability

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -16,21 +16,19 @@ data/resources/ui/vaults_page_row_settings_dialog.ui
 data/resources/ui/window.ui
 
 # src/
-src/ui/pages/mod.rs
-src/ui/pages/vaults_page_row_settings_dialog.rs
-src/ui/pages/vaults_page.rs
-src/ui/pages/vaults_page_row_password_prompt_dialog.rs
-src/ui/pages/vaults_page_row.rs
-src/ui/pages/start_page.rs
-src/ui/mod.rs
-src/ui/import_vault_dialog.rs
+src/application.rs
+src/backend/cryfs.rs
+src/backend/gocryptfs.rs
+src/backend/mod.rs
+src/config.rs
+src/main.rs
+src/mod.rs
 src/ui/add_new_vault_dialog.rs
+src/ui/import_vault_dialog.rs
+src/ui/mod.rs
+src/ui/pages/mod.rs
+src/ui/pages/vaults_page_row.rs
+src/ui/pages/vaults_page_row_password_prompt_dialog.rs
+src/ui/pages/vaults_page_row_settings_dialog.rs
 src/ui/window.rs
 src/user_config_manager.rs
-src/mod.rs
-src/main.rs
-src/config.rs
-src/backend/cryfs.rs
-src/backend/mod.rs
-src/backend/gocryptfs.rs
-src/application.rs


### PR DESCRIPTION
I deleted the two old references to `src/ui/pages/start_page.rs` and `src/ui/pages/vaults_page.rs`. Both files were already removed a while back in 61c8441a84245cb3ba1187322acaae6593eeafe1. I also reordered the `# src/`-part, so that it's arranged like the rest of the list for better readability.