### PR TITLE
Redesign Vaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "autocfg"
@@ -172,7 +172,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -781,9 +781,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -841,34 +841,34 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "e91f70896d6720bc714a4a57d22fc91f1db634680e65c8efe13323f1fa38d53f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "a6250dde8342e0232232be9ca3db7aa40aceb5a3e5dd9bddbc00d99a007cde49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -911,7 +911,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 
 [[package]]
 name = "temp-dir"
@@ -987,7 +987,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.13"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vaults"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ strum = "0.25"
 strum_macros = "0.25"
 toml = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
-adw = { version = "0.4", package = "libadwaita", features = ["v1_3"] }
+adw = { version = "0.4", package = "libadwaita", features = ["v1_4"] }
 gtk = { version = "0.6", package = "gtk4", features = ["v4_10"]}
 proc-mounts = "0.3"

--- a/data/resources/ui/vaults_page_row_password_prompt_dialog.ui
+++ b/data/resources/ui/vaults_page_row_password_prompt_dialog.ui
@@ -14,33 +14,23 @@
         <property name="title" translatable="yes">Unlock Vault</property>
         <property name="description" translatable="yes">Enter the password to unlock the Vault.</property>
         <child>
-          <object class="GtkBox">
-            <property name="valign">center</property>
+          <object class="AdwPreferencesGroup">
             <child>
-              <object class="GtkPasswordEntry" id="password_entry">
-                <property name="margin-start">12</property>
-                <property name="margin-top">12</property>
-                <property name="margin-bottom">12</property>
-                <property name="placeholder_text">Password</property>
-                <property name="show-peek-icon">True</property>
-                <property name="hexpand">True</property>
+              <object class="AdwPasswordEntryRow" id="password_entry_row">
+                <property name="title" translatable="yes">Password</property>
+                <child type="suffix">
+                  <object class="GtkButton" id="unlock_button">
+                    <property name="valign">center</property>
+                    <property name="halign">center</property>
+                    <property name="icon_name">changes-allow-symbolic</property>
+                    <property name="tooltip-text" translatable="yes">Copy</property>
+                    <style>
+                      <class name="flat"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
-            <child type="end">
-              <object class="GtkButton" id="unlock_button">
-                <property name="margin-end">12</property>
-                <property name="margin-top">12</property>
-                <property name="margin-bottom">12</property>
-                <property name="icon_name">changes-allow-symbolic</property>
-                <property name="sensitive">False</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
-              </object>
-            </child>
-            <style>
-              <class name="linked"/>
-            </style>
           </object>
         </child>
       </object>

--- a/io.github.mpobaschnig.Vaults.Devel.json
+++ b/io.github.mpobaschnig.Vaults.Devel.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.mpobaschnig.Vaults.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/src/ui/pages/vaults_page_row_password_prompt_dialog.rs
+++ b/src/ui/pages/vaults_page_row_password_prompt_dialog.rs
@@ -33,7 +33,7 @@ mod imp {
         #[template_child]
         pub unlock_button: TemplateChild<gtk::Button>,
         #[template_child]
-        pub password_entry: TemplateChild<gtk::PasswordEntry>,
+        pub password_entry_row: TemplateChild<adw::PasswordEntryRow>,
         #[template_child]
         pub status_page: TemplateChild<adw::StatusPage>,
     }
@@ -47,7 +47,7 @@ mod imp {
         fn new() -> Self {
             Self {
                 unlock_button: TemplateChild::default(),
-                password_entry: TemplateChild::default(),
+                password_entry_row: TemplateChild::default(),
                 status_page: TemplateChild::default(),
             }
         }
@@ -107,13 +107,13 @@ impl VaultsPageRowPasswordPromptDialog {
             }));
 
         self.imp()
-            .password_entry
+            .password_entry_row
             .connect_text_notify(clone!(@weak self as obj => move |_| {
                 obj.check_unlock_button_enable_conditions();
             }));
 
         self.imp()
-            .password_entry
+            .password_entry_row
             .connect_activate(clone!(@weak self as obj => move |_| {
                 obj.connect_activate();
             }));
@@ -128,7 +128,7 @@ impl VaultsPageRowPasswordPromptDialog {
     }
 
     fn check_unlock_button_enable_conditions(&self) {
-        let vault_name = self.imp().password_entry.text();
+        let vault_name = self.imp().password_entry_row.text();
 
         if !vault_name.is_empty() {
             self.imp().unlock_button.set_sensitive(true);
@@ -138,12 +138,12 @@ impl VaultsPageRowPasswordPromptDialog {
     }
 
     fn connect_activate(&self) {
-        if !self.imp().password_entry.text().is_empty() {
+        if !self.imp().password_entry_row.text().is_empty() {
             self.unlock_button_clicked();
         }
     }
 
     pub fn get_password(&self) -> String {
-        self.imp().password_entry.text().to_string()
+        self.imp().password_entry_row.text().to_string()
     }
 }


### PR DESCRIPTION
This pull request addresses https://github.com/mpobaschnig/vaults/issues/54. We should also address the design for possible inclusion of https://github.com/mpobaschnig/vaults/issues/56

Tasks:
- [ ] Use AdwPreferencesRow et al. instead of GtkLabel/GtkEntry
- [ ] Use GtkPopover instead of GtkExpander with GtkLabel
- [ ] Explore alternative ways for apply/save/remove buttons, especially with new widgets
- [ ] https://github.com/mpobaschnig/vaults/issues/40
- [ ] https://github.com/mpobaschnig/vaults/issues/60
- [ ] https://github.com/mpobaschnig/vaults/issues/59
- [x] https://github.com/mpobaschnig/vaults/issues/58