### PR TITLE
flatpak: Add gocryptfs and cryfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,10 +99,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "env_logger"
@@ -266,6 +307,17 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -652,6 +704,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "pango"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +850,17 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
 
 [[package]]
 name = "rustc_version"
@@ -945,6 +1018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1086,7 @@ dependencies = [
  "pretty_env_logger",
  "proc-mounts",
  "quick-error",
+ "rust-ini",
  "serde",
  "strum",
  "strum_macros",
@@ -1009,6 +1098,12 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ adw = { version = "0.7", package = "libadwaita", features = ["v1_4"] }
 gtk = { version = "0.9", package = "gtk4", features = ["v4_14"] }
 proc-mounts = "0.3"
 async-channel = "2"
+rust-ini = "0.21"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 Vaults lets you create encrypted vaults in which you can safely store files.
 It currently uses [gocryptfs](https://github.com/rfjakob/gocryptfs) and [CryFS](https://github.com/cryfs/cryfs/) for encryption.  Please always keep a backup of your encrypted files.
 
-This version does not bundle [gocryptfs](https://github.com/rfjakob/gocryptfs) and [CryFS](https://github.com/cryfs/cryfs/) yet, so you need to install them on the host.
-
 # How to build
 
 Open GNOME Builder (or Visual Studio Code with the Flatpak extension), clone the repository, build and run it.

--- a/build-aux/cryfs.patch
+++ b/build-aux/cryfs.patch
@@ -1,0 +1,12 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+--- a/cmake-utils/Dependencies.cmake	2024-10-05 12:58:55.251047674 +0300
++++ b/cmake-utils/Dependencies.cmake	2024-10-05 11:52:02.039197519 +0300
+@@ -4,7 +4,7 @@
+ target_link_libraries(CryfsDependencies_range-v3 INTERFACE range-v3::range-v3)
+
+ # Setup boost dependency
+-set(Boost_USE_STATIC_LIBS OFF)
++set(Boost_USE_STATIC_LIBS ON)
+ find_package(Boost 1.84.0
+         REQUIRED
+         COMPONENTS filesystem system thread chrono program_options)

--- a/build-aux/fuse-2.9.2-namespace-conflict-fix.patch
+++ b/build-aux/fuse-2.9.2-namespace-conflict-fix.patch
@@ -1,0 +1,22 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+diff -up fuse-2.9.2/include/fuse_kernel.h.conflictfix fuse-2.9.2/include/fuse_kernel.h
+--- fuse-2.9.2/include/fuse_kernel.h.conflictfix	2013-06-26 09:31:57.862198038 -0400
++++ fuse-2.9.2/include/fuse_kernel.h	2013-06-26 09:32:19.679198365 -0400
+@@ -88,12 +88,16 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+
+-#include <sys/types.h>
++#ifdef __linux__
++#include <linux/types.h>
++#else
++#include <stdint.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t
+ #define __s32 int32_t
+ #define __u16 uint16_t
++#endif
+
+ /*
+  * Version negotiation:

--- a/build-aux/fuse-closefrom.patch
+++ b/build-aux/fuse-closefrom.patch
@@ -1,0 +1,21 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+diff --git a/util/ulockmgr_server.c b/util/ulockmgr_server.c
+index 273c7d923..a04dac5c6 100644
+--- a/util/ulockmgr_server.c
++++ b/util/ulockmgr_server.c
+@@ -124,6 +128,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
+ 	return res;
+ }
+
++#if 0
+ static int closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+@@ -141,6 +146,7 @@ static int closefrom(int minfd)
+ 	}
+ 	return 0;
+ }
++#endif
+
+ static void send_reply(int cfd, struct message *msg)
+ {

--- a/build-aux/fuse-disable-sys-mount-under-flatpak.patch
+++ b/build-aux/fuse-disable-sys-mount-under-flatpak.patch
@@ -1,0 +1,26 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+From 1ec935f4abecd08957affc7b21bae6bf5be78931 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Thu, 12 Apr 2018 01:47:57 -0700
+Subject: [PATCH] libfuse: disable sys mount under flatpak
+
+---
+ lib/mount.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/mount.c b/lib/mount.c
+index 7a18c11..1667db2 100644
+--- a/lib/mount.c
++++ b/lib/mount.c
+@@ -392,6 +392,9 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
+ 	int fd;
+ 	int res;
+
++	/* disable in flatpak */
++	return -2;
++
+ 	if (!mnt) {
+ 		fprintf(stderr, "fuse: missing mountpoint parameter\n");
+ 		return -1;
+--
+2.17.0.rc2

--- a/build-aux/gocryptfs.patch
+++ b/build-aux/gocryptfs.patch
@@ -1,0 +1,25 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+--- a/Makefile	2023-06-10 17:31:49.000000000 +0300
++++ b/Makefile	2024-10-02 20:56:16.832488450 +0300
+@@ -1,7 +1,6 @@
+ .phony: build
+ build:
+ 	./build.bash
+-	./Documentation/MANPAGE-render.bash
+
+ .phony: test
+ test:
+@@ -23,11 +22,8 @@
+ # Keep in sync with uninstall!
+ .phony: install
+ install:
+-	install -Dm755 -t "$(DESTDIR)/usr/bin/" gocryptfs
+-	install -Dm755 -t "$(DESTDIR)/usr/bin/" gocryptfs-xray/gocryptfs-xray
+-	install -Dm644 -t "$(DESTDIR)/usr/share/man/man1/" Documentation/gocryptfs.1
+-	install -Dm644 -t "$(DESTDIR)/usr/share/man/man1/" Documentation/gocryptfs-xray.1
+-	install -Dm644 -t "$(DESTDIR)/usr/share/licenses/gocryptfs" LICENSE
++	install -Dm755 -t "/app/bin/" gocryptfs
++
+
+ .phony: uninstall
+ uninstall:

--- a/build-aux/gocryptfs_version.patch
+++ b/build-aux/gocryptfs_version.patch
@@ -1,0 +1,14 @@
+# From: https://github.com/flathub/io.github.mhogomchungu.sirikali/tree/master/patches
+--- a/version.go	2023-06-10 17:31:49.000000000 +0300
++++ b/version.go	2024-10-03 00:58:27.203740817 +0300
+@@ -47,8 +47,8 @@
+ 	if raceDetector {
+ 		built += " -race"
+ 	}
+-	fmt.Printf("%s %s%s; go-fuse %s; %s %s/%s\n",
+-		tlog.ProgramName, GitVersion, tags, GitVersionFuse, built,
++	fmt.Printf("%s v2.4.0%s; go-fuse %s; %s %s/%s\n",
++		tlog.ProgramName,  tags, GitVersionFuse, built,
+ 		runtime.GOOS, runtime.GOARCH)
+ }
+

--- a/data/io.github.mpobaschnig.Vaults.metainfo.xml.in.in
+++ b/data/io.github.mpobaschnig.Vaults.metainfo.xml.in.in
@@ -7,7 +7,6 @@
   <summary>Keep important files safe</summary>
   <description>
     <p>Vaults lets you create encrypted vaults in which you can safely store files. It uses gocryptfs and CryFS for encryption.</p>
-    <p>Note: This version does not bundle gocryptfs and CryFS yet, so you need to install them on the host.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/io.github.mpobaschnig.Vaults.Devel.json
+++ b/io.github.mpobaschnig.Vaults.Devel.json
@@ -35,58 +35,30 @@
     "modules": [
         {
             "name": "libfuse",
-            "buildsystem": "meson",
+            "buildsystem": "autotools",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "*.a",
+                "*.la",
+                "/lib/libulockmgr*"
+            ],
             "config-opts": [
-                "-Dexamples=false",
-                "-Duseroot=false",
-                "-Dtests=false",
-                "-Dudevrulesdir=/tmp/",
-                "-Dinitscriptdir="
+                "--disable-util"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libfuse/libfuse/releases/download/fuse-3.12.0/fuse-3.12.0.tar.xz",
-                    "sha256": "33b8a92d6f7a88e6a889f0009206933482f48f3eb85d88cf09ef551313ac7373"
-                }
-            ]
-        },
-        {
-            "name": "wrapper",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install fusermount-wrapper.sh /app/bin/fusermount3"
-            ],
-            "sources": [
+                    "url": "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz",
+                    "sha256": "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
+                },
                 {
-                    "type": "file",
-                    "path": "build-aux/fusermount-wrapper.sh"
-                }
-            ]
-        },
-        {
-            "name": "cryfs",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install cryfs-wrapper.sh /app/bin/cryfs"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "path": "build-aux/cryfs-wrapper.sh"
-                }
-            ]
-        },
-        {
-            "name": "cryfs-unmount",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install cryfs-unmount-wrapper.sh /app/bin/cryfs-unmount"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "path": "build-aux/cryfs-unmount-wrapper.sh"
+                    "type": "patch",
+                    "paths": [
+                        "build-aux/fuse-disable-sys-mount-under-flatpak.patch",
+                        "build-aux/fuse-2.9.2-namespace-conflict-fix.patch",
+                        "build-aux/fuse-closefrom.patch"
+                    ]
                 }
             ]
         },
@@ -94,12 +66,133 @@
             "name": "gocryptfs",
             "buildsystem": "simple",
             "build-commands": [
-                "install gocryptfs-wrapper.sh /app/bin/gocryptfs"
+                "mkdir -p /app/bin/",
+                "ln -s `pwd`/bin/go /app/bin/go",
+                "`pwd`/build-without-openssl.bash",
+                "make install",
+                "rm -rf /app/bin/go"
+            ],
+            "cleanup": [],
+            "config-opts": [],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/rfjakob/gocryptfs/releases/download/v2.4.0/gocryptfs_v2.4.0_src-deps.tar.gz",
+                    "sha256": "45158daf20df7f94e0c9ec57ba07af21df2e25e15b8584bf3c7de96adbbc2efd"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "build-aux/gocryptfs.patch",
+                        "build-aux/gocryptfs_version.patch"
+                    ]
+                },
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://go.dev/dl/go1.23.2.linux-amd64.tar.gz",
+                    "sha256": "542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e"
+                },
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://go.dev/dl/go1.23.2.linux-arm64.tar.gz",
+                    "sha256": "f626cdd92fc21a88b31c1251f419c17782933a42903db87a174ce74eeecc66a9"
+                }
+            ]
+        },
+        {
+            "name": "range-v3",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ericniebler/range-v3/archive/refs/tags/0.12.0.tar.gz",
+                    "sha256": "015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb"
+                }
+            ]
+        },
+        {
+            "name": "spdlog",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/gabime/spdlog/archive/refs/tags/v1.14.1.tar.gz",
+                    "sha256": "1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b"
+                }
+            ]
+        },
+        {
+            "name": "boost",
+            "buildsystem": "simple",
+            "build-commands": [
+                "`pwd`/bootstrap.sh --prefix=/app",
+                "`pwd`/b2 install --prefix=/app"
+            ],
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz",
+                    "sha256": "2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f"
+                }
+            ]
+        },
+        {
+            "name": "cryfs",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RELEASE",
+                "-DCRYFS_UPDATE_CHECKS=FALSE",
+                "-DDISABLE_OPENMP=ON",
+                "-DBoost_USE_STATIC_LIBS=ON"
+            ],
+            "cleanup": [
+                "/share/*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/cryfs/cryfs/archive/refs/tags/1.0.0-rc1.tar.gz",
+                    "sha256": "7d89ba1302fd6bbf92ad9a06779ed74eca5539052e78309bf10bbbc1d6fe0285"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "build-aux/cryfs.patch"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "wrapper",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install fusermount-wrapper.sh /app/bin/fusermount"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "path": "build-aux/gocryptfs-wrapper.sh"
+                    "path": "build-aux/fusermount-wrapper.sh"
                 }
             ]
         },

--- a/src/backend/cryfs.rs
+++ b/src/backend/cryfs.rs
@@ -64,7 +64,8 @@ pub fn open(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
 }
 
 pub fn close(vault_config: &VaultConfig) -> Result<(), BackendError> {
-    let child = Command::new("cryfs-unmount")
+    let child = Command::new("fusermount")
+        .arg("-u")
         .stdout(Stdio::piped())
         .arg(&vault_config.mount_directory)
         .spawn()?;

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -220,4 +220,8 @@ impl GlobalConfigManager {
             .mount_directory
             .borrow_mut() = path;
     }
+
+    pub fn get_flatpak_info(&self) -> Ini {
+        self.imp().flatpak_info.borrow().clone()
+    }
 }

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -21,6 +21,7 @@ use gtk::{
     gio::subclass::prelude::*,
     glib::{self, home_dir, user_config_dir, user_data_dir},
 };
+use ini::Ini;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use toml::de::Error;
@@ -52,6 +53,7 @@ mod imp {
         pub user_config_directory: RefCell<Option<String>>,
 
         pub global_config: RefCell<GlobalConfig>,
+        pub flatpak_info: RefCell<Ini>,
     }
 
     #[glib::object_subclass]
@@ -67,6 +69,7 @@ mod imp {
                     encrypted_data_directory: RefCell::new(String::from("".to_string())),
                     mount_directory: RefCell::new(String::from("".to_string())),
                 }),
+                flatpak_info: RefCell::new(Ini::new()),
             }
         }
     }
@@ -94,6 +97,9 @@ impl GlobalConfigManager {
 
     fn new() -> Self {
         let object: Self = glib::Object::new();
+
+        *object.imp().flatpak_info.borrow_mut() =
+            Ini::load_from_file("/.flatpak-info").expect("Could not load .flatpak-info");
 
         match user_config_dir().as_os_str().to_str() {
             Some(user_config_directory) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod ui;
 
 #[macro_use]
 extern crate quick_error;
+extern crate ini;
 extern crate proc_mounts;
 extern crate serde;
 extern crate toml;


### PR DESCRIPTION
This PR bundles gocryptfs and cryfs in the flatpak. In addition, we let the user set custom paths to the binaries.

Continuation of https://github.com/mpobaschnig/vaults/issues/8

Closes: #8 
