### PR TITLE
cryfs: Add "--allow-replaced-filesystem" flag when creating the vault

### DIFF
--- a/src/backend/cryfs.rs
+++ b/src/backend/cryfs.rs
@@ -70,6 +70,7 @@ pub fn init(vault_config: &VaultConfig, password: String) -> Result<(), BackendE
         .env("CRYFS_FRONTEND", "noninteractive")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .arg("--allow-replaced-filesystem")
         .arg(&vault_config.encrypted_data_directory)
         .arg(&vault_config.mount_directory)
         .spawn()?;


### PR DESCRIPTION
Since CryFS does not have an explicit "init" flag, we can safely ignore the change of ID when creating a new vault. We only need to careful when we open it.

Closes: #131 