### PR TITLE
global_config_manager: Check for None values in cryfs/gocryptfs binary

### DIFF
--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -261,7 +261,7 @@ impl GlobalConfigManager {
             .borrow()
             .cryfs_custom_binary
             .borrow())
-        .unwrap()
+        .unwrap_or(false)
     }
 
     pub fn set_cryfs_custom_binary(&self, enabled: bool) {
@@ -307,7 +307,7 @@ impl GlobalConfigManager {
             .borrow()
             .gocryptfs_custom_binary
             .borrow())
-        .unwrap()
+        .unwrap_or(false)
     }
 
     pub fn set_gocryptfs_custom_binary(&self, enabled: bool) {


### PR DESCRIPTION
Since we move to the GSettings preferences, we might not have values in our global config anymore. So check for this now.