### PR TITLE
Refactor user config, vault, and state handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "cairo-rs"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,7 +119,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -317,7 +323,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -589,6 +607,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +855,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "regex"
@@ -1086,6 +1120,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vaults"
 version = "0.11.0"
 dependencies = [
@@ -1104,6 +1150,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -1117,6 +1164,73 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -1229,4 +1343,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ gtk = { version = "0.9", package = "gtk4", features = ["v4_14"] }
 proc-mounts = "0.3"
 async-channel = "2"
 rust-ini = "0.21"
+uuid = { version = "1.17", features = ["serde", "v4"] }

--- a/data/io.github.mpobaschnig.Vaults.gschema.xml.in
+++ b/data/io.github.mpobaschnig.Vaults.gschema.xml.in
@@ -16,10 +16,6 @@
             <summary>Default window maximized behaviour</summary>
             <description></description>
         </key>
-        <key name="select-vaults" type="b">
-            <default>false</default>
-            <summary>Vault selection state</summary>
-        </key>
         <key name="legacy-converted" type="b">
             <default>false</default>
             <summary>Status of legacy conversion</summary>

--- a/data/io.github.mpobaschnig.Vaults.gschema.xml.in
+++ b/data/io.github.mpobaschnig.Vaults.gschema.xml.in
@@ -16,6 +16,10 @@
             <summary>Default window maximized behaviour</summary>
             <description></description>
         </key>
+        <key name="select-vaults" type="b">
+            <default>false</default>
+            <summary>Vault selection state</summary>
+        </key>
         <key name="legacy-converted" type="b">
             <default>false</default>
             <summary>Status of legacy conversion</summary>

--- a/data/resources/ui/vaults_page_row.ui
+++ b/data/resources/ui/vaults_page_row.ui
@@ -8,6 +8,17 @@
     <child>
       <object class="AdwActionRow" id="vaults_page_row">
         <property name="title" translatable="yes">Vault X</property>
+        <property name="activatable_widget">select_vault_button</property>
+        <child type="prefix">
+          <object class="GtkCheckButton" id="select_vault_button">
+            <property name="valign">center</property>
+            <property name="tooltip-text" translatable="yes">Select Vault</property>
+            <property name="group">select_vault_button</property>
+            <style>
+              <class name="selection-mode"/>
+            </style>
+          </object>
+        </child>
         <child>
           <object class="GtkButton" id="open_folder_button">
             <property name="valign">center</property>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -19,6 +19,9 @@
                 <property name="icon_name">user-trash-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Remove Vaults</property>
                 <property name="visible">False</property>
+                <style>
+                  <class name="destructive-action"/>
+                </style>
               </object>
             </child>
             <property name="title-widget">

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -31,6 +31,12 @@
               </object>
             </child>
             <child type="end">
+              <object class="GtkToggleButton" id="select_toggle_button">
+                <property name="icon_name">selection-mode-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Select Vaults</property>
+              </object>
+            </child>
+            <child type="end">
               <object class="GtkToggleButton" id="search_toggle_button">
                 <property name="icon_name">system-search-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Toggle Search</property>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -14,6 +14,13 @@
                 <property name="menu_model">add_menu</property>
               </object>
             </child>
+            <child>
+              <object class="GtkButton" id="remove_button">
+                <property name="icon_name">user-trash-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Remove Vaults</property>
+                <property name="visible">False</property>
+              </object>
+            </child>
             <property name="title-widget">
               <object class="GtkStackPage">
                 <property name="name">title</property>

--- a/src/application.rs
+++ b/src/application.rs
@@ -108,10 +108,13 @@ mod imp {
                     self.window.replace(Some(window));
 
                     let map = UserConfigManager::instance().get_map();
-                    let vault_config = map.get(&*self.only_pompt_vault.borrow());
+                    let vault = map
+                        .iter()
+                        .find(|&kv| kv.1.name == *self.only_pompt_vault.borrow());
 
-                    match vault_config {
-                        Some(vault_config) => {
+                    match vault {
+                        Some(vault) => {
+                            let vault_config = vault.1;
                             log::debug!(
                                 "Opening vault {:?}: {:?}",
                                 *self.only_pompt_vault.borrow(),
@@ -158,17 +161,20 @@ mod imp {
                     self.window.replace(Some(window));
 
                     let map = UserConfigManager::instance().get_map();
-                    let vault_config = map.get(&*self.only_pompt_vault.borrow());
+                    let vault = map
+                        .iter()
+                        .find(|&kv| kv.1.name == *self.only_pompt_vault.borrow());
 
-                    match vault_config {
-                        Some(vault_config) => {
+                    match vault {
+                        Some(vault) => {
+                            let vault_config = vault.1;
                             log::debug!(
                                 "Closing vault {:?}: {:?}",
                                 *self.only_pompt_vault.borrow(),
                                 &vault_config
                             );
 
-                            let result = Backend::close(vault_config);
+                            let result = Backend::close(&vault_config);
                             match result {
                                 Ok(_) => log::info!("Closed vault successfully."),
                                 Err(e) => log::error!("{e}"),

--- a/src/application.rs
+++ b/src/application.rs
@@ -174,7 +174,7 @@ mod imp {
                                 &vault_config
                             );
 
-                            let result = Backend::close(&vault_config);
+                            let result = Backend::close(vault_config);
                             match result {
                                 Ok(_) => log::info!("Closed vault successfully."),
                                 Err(e) => log::error!("{e}"),

--- a/src/backend/gocryptfs.rs
+++ b/src/backend/gocryptfs.rs
@@ -26,11 +26,11 @@ use gtk::gio::prelude::SettingsExt;
 use std::process::Command;
 use std::{io::Write, process::Stdio};
 
-fn get_binary_path(settings: &Settings, vault_config: &VaultConfig) -> String {
+fn get_binary_path(settings: &Settings, vault_config: &VaultConfig) -> Option<String> {
     log::trace!("get_binary_path({:?})", vault_config);
 
     if settings.boolean("use-custom-gocryptfs-binary") {
-        return settings.string("custom-gocryptfs-binary-path").to_string();
+        return Some(settings.string("custom-gocryptfs-binary-path").to_string());
     }
 
     GlobalConfigManager::instance().get_gocryptfs_binary_path()
@@ -39,9 +39,17 @@ fn get_binary_path(settings: &Settings, vault_config: &VaultConfig) -> String {
 pub fn is_available(settings: &Settings, vault_config: &VaultConfig) -> Result<bool, BackendError> {
     log::trace!("is_available({:?})", vault_config);
 
+    let binary_path = get_binary_path(settings, vault_config);
+    if binary_path.is_none() {
+        log::error!("gocryptfs binary path is not set");
+        return Err(BackendError::ToUser(gettext(
+            "No gocryptfs binary path set",
+        )));
+    }
+
     let output = Command::new("flatpak-spawn")
         .arg("--host")
-        .arg(get_binary_path(settings, vault_config))
+        .arg(binary_path.unwrap())
         .arg("--version")
         .output()?;
     log::debug!("gocryptfs output: {:?}", output);
@@ -58,9 +66,17 @@ pub fn init(
 ) -> Result<(), BackendError> {
     log::trace!("init({:?}, password: <redacted>)", vault_config);
 
+    let binary_path = get_binary_path(settings, vault_config);
+    if binary_path.is_none() {
+        log::error!("gocryptfs binary path is not set");
+        return Err(BackendError::ToUser(gettext(
+            "No gocryptfs binary path set",
+        )));
+    }
+
     let mut child = Command::new("flatpak-spawn")
         .arg("--host")
-        .arg(get_binary_path(settings, vault_config))
+        .arg(binary_path.unwrap())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .arg("--init")
@@ -102,9 +118,17 @@ pub fn open(
 ) -> Result<(), BackendError> {
     log::trace!("open({:?}, password: <redacted>)", vault_config);
 
+    let binary_path = get_binary_path(settings, vault_config);
+    if binary_path.is_none() {
+        log::error!("gocryptfs binary path is not set");
+        return Err(BackendError::ToUser(gettext(
+            "No gocryptfs binary path set",
+        )));
+    }
+
     let mut child = Command::new("flatpak-spawn")
         .arg("--host")
-        .arg(get_binary_path(settings, vault_config))
+        .arg(binary_path.unwrap())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .arg("-q")

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -22,7 +22,7 @@ pub mod gocryptfs;
 
 use crate::{config::APP_ID, vault::VaultConfig};
 use gettextrs::gettext;
-use gtk::gio::Settings;
+use gtk::{gio::Settings, glib};
 use serde::{Deserialize, Serialize};
 use std::string::String;
 use strum_macros::EnumIter;
@@ -48,9 +48,15 @@ quick_error! {
     strum_macros::EnumString,
     Copy,
     Clone,
+    glib::Enum,
+    Default,
 )]
+#[enum_type(name = "Backend")]
 pub enum Backend {
+    #[default]
+    #[enum_value(name = "cryfs")]
     Cryfs,
+    #[enum_value(name = "gocryptfs")]
     Gocryptfs,
 }
 

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -355,6 +355,11 @@ impl GlobalConfigManager {
                 if exists {
                     log::info!("cryfs binary exists, taking it");
                     return Some(cryfs_instance_path);
+                } else {
+                    log::error!(
+                        "cryfs binary does not exist at path: {}",
+                        cryfs_instance_path
+                    );
                 }
             }
             Err(e) => {
@@ -376,6 +381,11 @@ impl GlobalConfigManager {
                 if exists {
                     log::info!("gocryptfs binary exists, taking it");
                     return Some(gocryptfs_instance_path);
+                } else {
+                    log::error!(
+                        "gocryptfs binary does not exist at path: {}",
+                        gocryptfs_instance_path
+                    );
                 }
             }
             Err(e) => {

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -346,11 +346,7 @@ impl GlobalConfigManager {
 
     pub fn get_cryfs_binary_path(&self) -> Option<String> {
         let flatpak_info = self.get_flatpak_info();
-        let instance_path = flatpak_info
-            .section(Some("Instance"))
-            .unwrap()
-            .get("app-path")
-            .unwrap();
+        let instance_path = flatpak_info.section(Some("Instance"))?.get("app-path")?;
         let cryfs_instance_path = instance_path.to_owned() + "/bin/cryfs";
         log::info!("CryFS binary path: {}", cryfs_instance_path);
         let exists = fs::exists(&cryfs_instance_path);

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -23,7 +23,7 @@ use gtk::{
 };
 use ini::Ini;
 use serde::{Deserialize, Serialize};
-use std::{cell::RefCell, fs, process::ExitStatus};
+use std::{cell::RefCell, fs};
 use toml::de::Error;
 
 use self::imp::GlobalConfig;

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -344,7 +344,7 @@ impl GlobalConfigManager {
             .borrow_mut() = Some(path);
     }
 
-    pub fn get_cryfs_binary_path(&self) -> String {
+    pub fn get_cryfs_binary_path(&self) -> Option<String> {
         let flatpak_info = self.get_flatpak_info();
         let instance_path = flatpak_info
             .section(Some("Instance"))
@@ -353,7 +353,20 @@ impl GlobalConfigManager {
             .unwrap();
         let cryfs_instance_path = instance_path.to_owned() + "/bin/cryfs";
         log::info!("CryFS binary path: {}", cryfs_instance_path);
-        cryfs_instance_path
+        let exists = fs::exists(&cryfs_instance_path);
+        match exists {
+            Ok(exists) => {
+                if exists {
+                    log::info!("cryfs binary exists, taking it");
+                    return Some(cryfs_instance_path);
+                }
+            }
+            Err(e) => {
+                log::error!("Error checking cryfs binary path existence: {}", e);
+            }
+        }
+
+        None
     }
 
     pub fn get_gocryptfs_binary_path(&self) -> Option<String> {

--- a/src/global_config_manager.rs
+++ b/src/global_config_manager.rs
@@ -358,11 +358,7 @@ impl GlobalConfigManager {
 
     pub fn get_gocryptfs_binary_path(&self) -> Option<String> {
         let flatpak_info = self.get_flatpak_info();
-        let instance_path = flatpak_info
-            .section(Some("Instance"))
-            .unwrap()
-            .get("app-path")
-            .unwrap();
+        let instance_path = flatpak_info.section(Some("Instance"))?.get("app-path")?;
         let gocryptfs_instance_path = instance_path.to_owned() + "/bin/gocryptfs";
         log::info!("gocryptfs binary path: {}", gocryptfs_instance_path);
         let exists = fs::exists(&gocryptfs_instance_path);

--- a/src/legacy/user_config.rs
+++ b/src/legacy/user_config.rs
@@ -47,8 +47,6 @@ pub fn get_user_config_from_legacy_config() -> HashMap<Uuid, VaultConfig> {
                 encrypted_data_directory: vault_config.encrypted_data_directory,
                 mount_directory: vault_config.mount_directory,
                 session_lock: vault_config.session_lock,
-                use_custom_binary: vault_config.use_custom_binary,
-                custom_binary_path: vault_config.custom_binary_path,
             };
             new_user_config.insert(util::generate_uuid(), new_vault_config);
         }

--- a/src/legacy/user_config.rs
+++ b/src/legacy/user_config.rs
@@ -1,0 +1,102 @@
+// user_config.rs
+//
+// Copyright 2025 Martin Pobaschnig
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::{backend::Backend, util, vault::VaultConfig};
+use gtk::glib::user_config_dir;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use toml::de::Error;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct LegacyVaultConfig {
+    pub backend: Backend,
+    pub encrypted_data_directory: String,
+    pub mount_directory: String,
+    pub session_lock: Option<bool>,
+    pub use_custom_binary: Option<bool>,
+    pub custom_binary_path: Option<String>,
+}
+
+pub fn get_user_config_from_legacy_config() -> HashMap<Uuid, VaultConfig> {
+    log::trace!("convert_legacy_user_config_to_new()");
+
+    let mut new_user_config: HashMap<Uuid, VaultConfig> = HashMap::new();
+    let legacy_user_config = read_legacy_user_config();
+    if let Some(legacy_user_config) = legacy_user_config {
+        for (name, vault_config) in legacy_user_config {
+            let new_vault_config = VaultConfig {
+                name,
+                backend: vault_config.backend,
+                encrypted_data_directory: vault_config.encrypted_data_directory,
+                mount_directory: vault_config.mount_directory,
+                session_lock: vault_config.session_lock,
+                use_custom_binary: vault_config.use_custom_binary,
+                custom_binary_path: vault_config.custom_binary_path,
+            };
+            new_user_config.insert(util::generate_uuid(), new_vault_config);
+        }
+    }
+
+    new_user_config
+}
+
+pub fn read_legacy_user_config() -> Option<HashMap<String, LegacyVaultConfig>> {
+    log::trace!("read_legacy_user_config()");
+
+    let legacy_user_config_path = get_legacy_user_config_path();
+
+    if let Some(legacy_user_config_path) = legacy_user_config_path {
+        let contents = std::fs::read_to_string(&legacy_user_config_path);
+        match contents {
+            Ok(content) => {
+                let res: Result<HashMap<String, LegacyVaultConfig>, Error> =
+                    toml::from_str(&content.clone());
+                match res {
+                    Ok(v) => {
+                        return Some(v);
+                    }
+                    Err(e) => {
+                        log::error!("Failed to parse user data config: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to read user data config: {}", e);
+            }
+        }
+    }
+
+    return None;
+}
+
+fn get_legacy_user_config_path() -> Option<String> {
+    log::trace!("get_legacy_user_config_path()");
+
+    match user_config_dir().as_os_str().to_str() {
+        Some(user_config_directory) => {
+            log::info!("Got user config dir: {}", user_config_directory);
+            Some(user_config_directory.to_owned() + "/user_config.toml")
+        }
+        None => {
+            log::error!("Could not get user data directory");
+            None
+        }
+    }
+}

--- a/src/legacy/user_config.rs
+++ b/src/legacy/user_config.rs
@@ -46,7 +46,7 @@ pub fn get_user_config_from_legacy_config() -> HashMap<Uuid, VaultConfig> {
                 backend: vault_config.backend,
                 encrypted_data_directory: vault_config.encrypted_data_directory,
                 mount_directory: vault_config.mount_directory,
-                session_lock: vault_config.session_lock,
+                session_lock: vault_config.session_lock.unwrap_or(false),
             };
             new_user_config.insert(util::generate_uuid(), new_vault_config);
         }

--- a/src/legacy/user_config.rs
+++ b/src/legacy/user_config.rs
@@ -81,7 +81,7 @@ pub fn read_legacy_user_config() -> Option<HashMap<String, LegacyVaultConfig>> {
         }
     }
 
-    return None;
+    None
 }
 
 fn get_legacy_user_config_path() -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod config;
 mod global_config_manager;
 mod legacy;
 mod user_config_manager;
+mod util;
 mod vault;
 
 mod backend;
@@ -34,6 +35,7 @@ extern crate ini;
 extern crate proc_mounts;
 extern crate serde;
 extern crate toml;
+extern crate uuid;
 
 use application::VApplication;
 use config::{GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_FILE};

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,6 +25,7 @@ sources = files(
 
   'legacy/global_config.rs',
   'legacy/mod.rs',
+  'legacy/user_config.rs',
 
   'ui/pages/mod.rs',
   'ui/pages/vaults_page_row.rs',
@@ -43,6 +44,7 @@ sources = files(
   'main.rs',
   'mod.rs',
   'user_config_manager.rs',
+  'util.rs',
   'vault.rs',
 )
 

--- a/src/ui/add_new_vault_window.rs
+++ b/src/ui/add_new_vault_window.rs
@@ -19,8 +19,7 @@
 
 use crate::application::VApplication;
 use crate::config::APP_ID;
-use crate::user_config_manager::UserConfigManager;
-use crate::{backend, vault::*};
+use crate::{backend, util, vault::*};
 use adw::prelude::AdwDialogExt;
 use adw::prelude::ComboRowExt;
 use gettextrs::gettext;
@@ -360,26 +359,6 @@ impl AddNewVaultWindow {
 
             return;
         }
-
-        let is_duplicate = UserConfigManager::instance()
-            .get_map()
-            .contains_key(&vault_name.to_string());
-
-        if is_duplicate {
-            self.imp().next_button.set_sensitive(false);
-
-            self.imp().entry_row_name.add_css_class("error");
-            self.imp().name_error_label.set_visible(true);
-            self.imp()
-                .name_error_label
-                .set_text(&gettext("Name is already taken."));
-        } else {
-            self.imp().next_button.set_sensitive(true);
-
-            self.imp().entry_row_name.remove_css_class("error");
-            self.imp().name_error_label.set_visible(false);
-            self.imp().name_error_label.set_text("");
-        }
     }
 
     pub fn combo_box_changed(&self) {
@@ -714,6 +693,7 @@ impl AddNewVaultWindow {
         .unwrap();
 
         Vault::new(
+            util::generate_uuid(),
             String::from(self.imp().entry_row_name.text().as_str()),
             backend,
             String::from(

--- a/src/ui/add_new_vault_window.rs
+++ b/src/ui/add_new_vault_window.rs
@@ -704,8 +704,6 @@ impl AddNewVaultWindow {
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
             None,
-            None,
-            None,
         )
     }
 

--- a/src/ui/add_new_vault_window.rs
+++ b/src/ui/add_new_vault_window.rs
@@ -348,14 +348,15 @@ impl AddNewVaultWindow {
             return;
         }
 
-        let vault_name = self.imp().entry_row_name.text();
+        self.imp().entry_row_name.remove_css_class("error");
+        self.imp().name_error_label.set_visible(false);
+        self.imp().name_error_label.set_text("");
 
+        let vault_name = self.imp().entry_row_name.text();
         if vault_name.is_empty() {
             self.imp().next_button.set_sensitive(false);
-
-            self.imp().entry_row_name.remove_css_class("error");
-            self.imp().name_error_label.set_visible(false);
-            self.imp().name_error_label.set_text("");
+        } else {
+            self.imp().next_button.set_sensitive(true);
         }
     }
 

--- a/src/ui/add_new_vault_window.rs
+++ b/src/ui/add_new_vault_window.rs
@@ -356,8 +356,6 @@ impl AddNewVaultWindow {
             self.imp().entry_row_name.remove_css_class("error");
             self.imp().name_error_label.set_visible(false);
             self.imp().name_error_label.set_text("");
-
-            return;
         }
     }
 

--- a/src/ui/add_new_vault_window.rs
+++ b/src/ui/add_new_vault_window.rs
@@ -703,7 +703,7 @@ impl AddNewVaultWindow {
                     .as_str(),
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
-            None,
+            false,
         )
     }
 

--- a/src/ui/import_vault_window.rs
+++ b/src/ui/import_vault_window.rs
@@ -25,7 +25,8 @@ use std::cell::RefCell;
 use strum::IntoEnumIterator;
 
 use crate::application::VApplication;
-use crate::{backend, user_config_manager::UserConfigManager, vault::*};
+use crate::util;
+use crate::{backend, vault::*};
 
 mod imp {
     use gtk::glib::subclass::Signal;
@@ -325,26 +326,6 @@ impl ImportVaultDialog {
             return;
         }
 
-        let is_duplicate = UserConfigManager::instance()
-            .get_map()
-            .contains_key(&vault_name.to_string());
-
-        if is_duplicate {
-            self.imp().import_button.set_sensitive(false);
-
-            self.imp().name_entry_row.add_css_class("error");
-            self.imp().name_error_label.set_visible(true);
-            self.imp()
-                .name_error_label
-                .set_text(&gettext("Name is already taken."));
-
-            return;
-        } else {
-            self.imp().name_entry_row.remove_css_class("error");
-            self.imp().name_error_label.set_visible(false);
-            self.imp().name_error_label.set_text("");
-        }
-
         self.imp().import_button.set_sensitive(true);
     }
 
@@ -596,6 +577,7 @@ impl ImportVaultDialog {
 
     pub fn get_vault(&self) -> Vault {
         Vault::new(
+            util::generate_uuid(),
             String::from(self.imp().name_entry_row.text().as_str()),
             backend::get_backend_from_ui_string(
                 &self

--- a/src/ui/import_vault_window.rs
+++ b/src/ui/import_vault_window.rs
@@ -599,8 +599,6 @@ impl ImportVaultDialog {
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
             None,
-            None,
-            None,
         )
     }
 

--- a/src/ui/import_vault_window.rs
+++ b/src/ui/import_vault_window.rs
@@ -598,7 +598,7 @@ impl ImportVaultDialog {
                     .as_str(),
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
-            None,
+            false,
         )
     }
 

--- a/src/ui/pages/vaults_page_row.rs
+++ b/src/ui/pages/vaults_page_row.rs
@@ -106,6 +106,7 @@ mod imp {
             obj.setup_connect_handlers();
 
             self.open_folder_button.set_visible(false);
+            self.select_vault_button.set_visible(false);
         }
 
         fn signals() -> &'static [Signal] {

--- a/src/ui/pages/vaults_page_row.rs
+++ b/src/ui/pages/vaults_page_row.rs
@@ -217,20 +217,18 @@ impl VaultsPageRow {
             self,
             move |_| {
                 let config = obj.imp().config.borrow().clone().unwrap();
-                if let Some(session_locking) = config.session_lock {
-                    if session_locking {
-                        let vault = obj.get_vault();
+                if config.session_lock {
+                    let vault = obj.get_vault();
 
-                        if !vault.is_backend_available() {
-                            obj.set_vault_row_state_backend_unavailable();
-                            return;
-                        } else {
-                            obj.set_vault_row_state_backend_available();
-                        }
+                    if !vault.is_backend_available() {
+                        obj.set_vault_row_state_backend_unavailable();
+                        return;
+                    } else {
+                        obj.set_vault_row_state_backend_available();
+                    }
 
-                        if obj.is_mounted() {
-                            obj.locker_button_clicked_is_mounted(vault);
-                        }
+                    if obj.is_mounted() {
+                        obj.locker_button_clicked_is_mounted(vault);
                     }
                 }
             }

--- a/src/ui/pages/vaults_page_row.rs
+++ b/src/ui/pages/vaults_page_row.rs
@@ -161,32 +161,6 @@ impl VaultsPageRow {
     }
 
     pub fn setup_connect_handlers(&self) {
-        self.imp().settings.connect_changed(
-            Some("select-vaults"),
-            clone!(
-                #[weak(rename_to = obj)]
-                self,
-                move |settings, key| {
-                    if key != "select-vaults" {
-                        return;
-                    }
-
-                    if !settings.boolean("select-vaults") {
-                        obj.imp().select_vault_button.set_active(false);
-                    }
-                }
-            ),
-        );
-
-        self.imp()
-            .settings
-            .bind(
-                "select-vaults",
-                &self.imp().select_vault_button.get(),
-                "visible",
-            )
-            .build();
-
         self.imp().open_folder_button.connect_clicked(clone!(
             #[weak(rename_to = obj)]
             self,

--- a/src/ui/pages/vaults_page_row.rs
+++ b/src/ui/pages/vaults_page_row.rs
@@ -532,8 +532,6 @@ impl VaultsPageRow {
                 config.encrypted_data_directory,
                 config.mount_directory,
                 config.session_lock,
-                config.use_custom_binary,
-                config.custom_binary_path,
             ),
             _ => {
                 log::error!("Vault not initialized!");

--- a/src/ui/pages/vaults_page_row.rs
+++ b/src/ui/pages/vaults_page_row.rs
@@ -138,16 +138,9 @@ impl VaultsPageRow {
     pub fn new(vault: Vault) -> Self {
         let object: Self = glib::Object::new();
 
-        match (vault.get_name(), vault.get_config()) {
-            (Some(name), Some(config)) => {
-                object.imp().vaults_page_row.set_title(&name);
-                object.imp().uuid.replace(Some(vault.get_uuid()));
-                object.imp().config.replace(Some(config));
-            }
-            (_, _) => {
-                log::error!("Vault(s) not initialised!");
-            }
-        }
+        object.imp().vaults_page_row.set_title(&vault.name());
+        object.imp().uuid.replace(Some(vault.get_uuid()));
+        object.imp().config.replace(Some(vault.config()));
 
         if vault.is_mounted() {
             object.set_vault_row_state_opened();
@@ -273,7 +266,7 @@ impl VaultsPageRow {
         }
 
         let (sender, receiver) = async_channel::unbounded();
-        let vault_config = vault.get_config().clone().unwrap();
+        let vault_config = vault.config().clone();
         let locker_button = self.imp().locker_button.clone();
         let open_folder_button = self.imp().open_folder_button.clone();
         let settings_button = self.imp().settings_button.clone();
@@ -348,7 +341,7 @@ impl VaultsPageRow {
         }
 
         let dialog = VaultsPageRowPasswordPromptWindow::new();
-        dialog.set_name(&vault.get_name().unwrap());
+        dialog.set_name(&vault.name());
         dialog.connect_closure(
             "unlock",
             false,
@@ -373,7 +366,7 @@ impl VaultsPageRow {
                     }
 
                     let (sender, receiver) = async_channel::unbounded();
-                    let vault_config = vault.get_config().clone().unwrap();
+                    let vault_config = vault.config().clone();
                     let locker_button = obj.imp().locker_button.clone();
                     let open_folder_button = obj.imp().open_folder_button.clone();
                     let settings_button = obj.imp().settings_button.clone();
@@ -542,18 +535,11 @@ impl VaultsPageRow {
         log::trace!("set_vault");
 
         let uuid = vault.get_uuid();
-        let name = vault.get_name();
-        let config = vault.get_config();
-        match (name, config) {
-            (Some(name), Some(config)) => {
-                self.imp().uuid.replace(Some(uuid));
-                self.imp().vaults_page_row.set_title(&name);
-                self.imp().config.replace(Some(config));
-            }
-            (_, _) => {
-                log::error!("Vault not initialized!");
-            }
-        }
+        let name = vault.name();
+        let config = vault.config();
+        self.imp().uuid.replace(Some(uuid));
+        self.imp().vaults_page_row.set_title(&name);
+        self.imp().config.replace(Some(config));
     }
 
     pub fn get_name(&self) -> String {

--- a/src/ui/pages/vaults_page_row_settings_window.rs
+++ b/src/ui/pages/vaults_page_row_settings_window.rs
@@ -81,10 +81,10 @@ mod imp {
             self.parent_constructed();
 
             self.name_entry_row
-                .set_text(&self.obj().vault().unwrap().get_name().unwrap());
+                .set_text(&self.obj().vault().unwrap().name());
 
             let mut model_position = 0;
-            let vault_backend = self.obj().vault().unwrap().get_config().unwrap().backend;
+            let vault_backend = self.obj().vault().unwrap().backend();
             let list = gtk::StringList::new(&[]);
             for (position, backend) in Backend::iter().enumerate() {
                 let backend = &backend::get_ui_string_from_backend(&backend);
@@ -96,34 +96,14 @@ mod imp {
             self.combo_row_backend.set_model(Some(&list));
             self.combo_row_backend.set_selected(model_position as u32);
 
-            self.encrypted_data_directory_entry_row.set_text(
-                &self
-                    .obj()
-                    .vault()
-                    .unwrap()
-                    .get_config()
-                    .unwrap()
-                    .encrypted_data_directory,
-            );
+            self.encrypted_data_directory_entry_row
+                .set_text(&self.obj().vault().unwrap().encrypted_data_directory());
 
-            self.mount_directory_entry_row.set_text(
-                &self
-                    .obj()
-                    .vault()
-                    .unwrap()
-                    .get_config()
-                    .unwrap()
-                    .mount_directory,
-            );
+            self.mount_directory_entry_row
+                .set_text(&self.obj().vault().unwrap().mount_directory());
 
-            self.lock_screen_switch_row.set_active(
-                self.obj()
-                    .vault()
-                    .unwrap()
-                    .get_config()
-                    .unwrap()
-                    .session_lock,
-            );
+            self.lock_screen_switch_row
+                .set_active(self.obj().vault().unwrap().session_lock());
 
             self.obj().connect_vault_notify(clone!(move |obj| {
                 obj.emit_by_name::<()>("save", &[]);
@@ -232,10 +212,8 @@ impl VaultsPageRowSettingsWindow {
             self.imp().lock_screen_switch_row.is_active(),
         );
 
-        UserConfigManager::instance().change_vault(
-            self.vault().unwrap().get_uuid(),
-            new_vault.get_config().unwrap().clone(),
-        );
+        UserConfigManager::instance()
+            .change_vault(self.vault().unwrap().get_uuid(), new_vault.config().clone());
         self.set_vault(new_vault);
         self.notify_vault();
     }

--- a/src/ui/pages/vaults_page_row_settings_window.rs
+++ b/src/ui/pages/vaults_page_row_settings_window.rs
@@ -209,6 +209,7 @@ impl VaultsPageRowSettingsWindow {
 
     fn apply_changes(&self) {
         let new_vault = Vault::new(
+            self.vault().unwrap().get_uuid(),
             String::from(self.imp().name_entry_row.text().as_str()),
             backend::get_backend_from_ui_string(
                 &self
@@ -242,7 +243,10 @@ impl VaultsPageRowSettingsWindow {
                 .custom_binary_path,
         );
 
-        UserConfigManager::instance().change_vault(self.vault().unwrap(), new_vault.clone());
+        UserConfigManager::instance().change_vault(
+            self.vault().unwrap().get_uuid(),
+            new_vault.get_config().unwrap().clone(),
+        );
         self.set_vault(new_vault);
         self.notify_vault();
     }
@@ -333,6 +337,7 @@ impl VaultsPageRowSettingsWindow {
 
     pub fn create_vault_from_settings(&self) -> Vault {
         Vault::new(
+            self.vault().unwrap().get_uuid(),
             String::from(self.imp().name_entry_row.text().as_str()),
             backend::get_backend_from_ui_string(
                 &self

--- a/src/ui/pages/vaults_page_row_settings_window.rs
+++ b/src/ui/pages/vaults_page_row_settings_window.rs
@@ -231,16 +231,6 @@ impl VaultsPageRowSettingsWindow {
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
             Some(self.imp().lock_screen_switch_row.is_active()),
-            self.vault()
-                .unwrap()
-                .get_config()
-                .unwrap()
-                .use_custom_binary,
-            self.vault()
-                .unwrap()
-                .get_config()
-                .unwrap()
-                .custom_binary_path,
         );
 
         UserConfigManager::instance().change_vault(
@@ -359,8 +349,6 @@ impl VaultsPageRowSettingsWindow {
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
             Some(self.imp().lock_screen_switch_row.is_active()),
-            Some(false),
-            None,
         )
     }
 }

--- a/src/ui/pages/vaults_page_row_settings_window.rs
+++ b/src/ui/pages/vaults_page_row_settings_window.rs
@@ -122,8 +122,7 @@ mod imp {
                     .unwrap()
                     .get_config()
                     .unwrap()
-                    .session_lock
-                    .unwrap_or(false),
+                    .session_lock,
             );
 
             self.obj().connect_vault_notify(clone!(move |obj| {
@@ -230,7 +229,7 @@ impl VaultsPageRowSettingsWindow {
                     .as_str(),
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
-            Some(self.imp().lock_screen_switch_row.is_active()),
+            self.imp().lock_screen_switch_row.is_active(),
         );
 
         UserConfigManager::instance().change_vault(
@@ -348,7 +347,7 @@ impl VaultsPageRowSettingsWindow {
                     .as_str(),
             ),
             String::from(self.imp().mount_directory_entry_row.text().as_str()),
-            Some(self.imp().lock_screen_switch_row.is_active()),
+            self.imp().lock_screen_switch_row.is_active(),
         )
     }
 }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -214,7 +214,7 @@ impl VaultsSettingsWindow {
                 &self.imp().gocryptfs_custom_binary_expander_row.get(),
                 "enable-expansion",
             )
-            .flags(SettingsBindFlags::GET)
+            .flags(SettingsBindFlags::INVERT_BOOLEAN)
             .build();
 
         self.imp()

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -214,7 +214,6 @@ impl VaultsSettingsWindow {
                 &self.imp().gocryptfs_custom_binary_expander_row.get(),
                 "enable-expansion",
             )
-            .flags(SettingsBindFlags::INVERT_BOOLEAN)
             .build();
 
         self.imp()

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -180,6 +180,9 @@ impl ApplicationWindow {
         ));
 
         self.imp().add_menu_button.set_sensitive(true);
+        self.imp()
+            .select_toggle_button
+            .set_sensitive(self.imp().list_store.n_items() > 0);
     }
 
     fn setup_search_page(&self) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -72,6 +72,8 @@ mod imp {
         pub add_menu_button: TemplateChild<gtk::MenuButton>,
         #[template_child]
         pub select_toggle_button: TemplateChild<gtk::ToggleButton>,
+        #[template_child]
+        pub remove_button: TemplateChild<gtk::Button>,
 
         pub list_store: ListStore,
         pub search_list_store: ListStore,
@@ -104,6 +106,7 @@ mod imp {
                 settings: gio::Settings::new(APP_ID),
                 add_menu_button: TemplateChild::default(),
                 select_toggle_button: TemplateChild::default(),
+                remove_button: TemplateChild::default(),
             }
         }
 
@@ -343,6 +346,11 @@ impl ApplicationWindow {
     }
 
     fn setup_signals(&self) {
+        self.imp()
+            .settings
+            .bind("select-vaults", &self.imp().remove_button.get(), "visible")
+            .build();
+
         self.imp()
             .settings
             .bind(

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -219,7 +219,6 @@ impl ApplicationWindow {
 
                 let row = VaultsPageRow::new(vault);
                 self.search_row_connect_remove(&row);
-                //self.row_connect_save(&row);
 
                 self.imp().search_list_store.insert_sorted(&row, |v1, v2| {
                     let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -361,7 +360,6 @@ impl ApplicationWindow {
 
             let row = VaultsPageRow::new(vault);
             self.row_connect_remove(&row);
-            //self.row_connect_save(&row);
 
             self.imp().list_store.insert_sorted(&row, |v1, v2| {
                 let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -429,44 +427,26 @@ impl ApplicationWindow {
         ));
     }
 
-    //pub fn row_connect_save(&self, row: &VaultsPageRow) {
-    //    row.connect_save(clone!(
-    //        #[weak(rename_to = _obj)]
-    //        self,
-    //        #[weak(rename_to = r)]
-    //        row,
-    //        move || {
-    //            let vault = UserConfigManager::instance().get_current_vault();
-    //            if let Some(vault) = vault {
-    //                r.set_vault(vault);
-    //            } else {
-    //                log::error!("Vault not initialised!");
-    //            }
-    //        }
-    //    ));
-    //}
-
     pub fn add_vault(&self) {
         // TODO: Updating model
-        //let vault = UserConfigManager::instance().get_current_vault();
+        let vault = UserConfigManager::instance().get_current_vault();
 
-        //if let Some(vault) = vault {
-        //    let row = VaultsPageRow::new(vault.clone());
-        //    self.row_connect_remove(&row);
-        //    self.row_connect_save(&row);
+        if let Some(vault) = vault {
+            let row = VaultsPageRow::new(vault.clone());
+            self.row_connect_remove(&row);
 
-        //    self.imp().list_store.insert_sorted(&row, |v1, v2| {
-        //        let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
-        //        let name1 = row1.get_name();
-        //        let row2 = v2.downcast_ref::<VaultsPageRow>().unwrap();
-        //        let name2 = row2.get_name();
-        //        name1.cmp(&name2)
-        //    });
+            self.imp().list_store.insert_sorted(&row, |v1, v2| {
+                let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
+                let name1 = row1.get_name();
+                let row2 = v2.downcast_ref::<VaultsPageRow>().unwrap();
+                let name2 = row2.get_name();
+                name1.cmp(&name2)
+            });
 
-        //    self.imp().search_toggle_button.set_sensitive(true);
-        //} else {
-        //    log::error!("Vault not initialised!");
-        //}
+            self.imp().search_toggle_button.set_sensitive(true);
+        } else {
+            log::error!("Vault not initialised!");
+        }
     }
 
     pub fn refresh_view(&self, map_is_empty: bool) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -200,7 +200,7 @@ impl ApplicationWindow {
         let mut found = false;
         let map = UserConfigManager::instance().get_map();
         for (k, v) in &map {
-            let k_search = &k.to_lowercase();
+            let k_search = &v.name.to_lowercase();
 
             if k_search.contains(&text.to_string().to_lowercase()) {
                 if !found {
@@ -209,7 +209,8 @@ impl ApplicationWindow {
                 }
 
                 let vault = Vault::new(
-                    k.to_owned(),
+                    *k,
+                    v.name.to_owned(),
                     v.backend,
                     v.encrypted_data_directory.to_owned(),
                     v.mount_directory.to_owned(),
@@ -220,7 +221,7 @@ impl ApplicationWindow {
 
                 let row = VaultsPageRow::new(vault);
                 self.search_row_connect_remove(&row);
-                self.row_connect_save(&row);
+                //self.row_connect_save(&row);
 
                 self.imp().search_list_store.insert_sorted(&row, |v1, v2| {
                     let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -352,7 +353,8 @@ impl ApplicationWindow {
         let map = UserConfigManager::instance().get_map();
         for (k, v) in map.iter() {
             let vault = Vault::new(
-                k.to_owned(),
+                *k,
+                v.name.to_owned(),
                 v.backend,
                 v.encrypted_data_directory.to_owned(),
                 v.mount_directory.to_owned(),
@@ -363,7 +365,7 @@ impl ApplicationWindow {
 
             let row = VaultsPageRow::new(vault);
             self.row_connect_remove(&row);
-            self.row_connect_save(&row);
+            //self.row_connect_save(&row);
 
             self.imp().list_store.insert_sorted(&row, |v1, v2| {
                 let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -431,43 +433,44 @@ impl ApplicationWindow {
         ));
     }
 
-    pub fn row_connect_save(&self, row: &VaultsPageRow) {
-        row.connect_save(clone!(
-            #[weak(rename_to = _obj)]
-            self,
-            #[weak(rename_to = r)]
-            row,
-            move || {
-                let vault = UserConfigManager::instance().get_current_vault();
-                if let Some(vault) = vault {
-                    r.set_vault(vault);
-                } else {
-                    log::error!("Vault not initialised!");
-                }
-            }
-        ));
-    }
+    //pub fn row_connect_save(&self, row: &VaultsPageRow) {
+    //    row.connect_save(clone!(
+    //        #[weak(rename_to = _obj)]
+    //        self,
+    //        #[weak(rename_to = r)]
+    //        row,
+    //        move || {
+    //            let vault = UserConfigManager::instance().get_current_vault();
+    //            if let Some(vault) = vault {
+    //                r.set_vault(vault);
+    //            } else {
+    //                log::error!("Vault not initialised!");
+    //            }
+    //        }
+    //    ));
+    //}
 
     pub fn add_vault(&self) {
-        let vault = UserConfigManager::instance().get_current_vault();
+        // TODO: Updating model
+        //let vault = UserConfigManager::instance().get_current_vault();
 
-        if let Some(vault) = vault {
-            let row = VaultsPageRow::new(vault.clone());
-            self.row_connect_remove(&row);
-            self.row_connect_save(&row);
+        //if let Some(vault) = vault {
+        //    let row = VaultsPageRow::new(vault.clone());
+        //    self.row_connect_remove(&row);
+        //    self.row_connect_save(&row);
 
-            self.imp().list_store.insert_sorted(&row, |v1, v2| {
-                let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
-                let name1 = row1.get_name();
-                let row2 = v2.downcast_ref::<VaultsPageRow>().unwrap();
-                let name2 = row2.get_name();
-                name1.cmp(&name2)
-            });
+        //    self.imp().list_store.insert_sorted(&row, |v1, v2| {
+        //        let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
+        //        let name1 = row1.get_name();
+        //        let row2 = v2.downcast_ref::<VaultsPageRow>().unwrap();
+        //        let name2 = row2.get_name();
+        //        name1.cmp(&name2)
+        //    });
 
-            self.imp().search_toggle_button.set_sensitive(true);
-        } else {
-            log::error!("Vault not initialised!");
-        }
+        //    self.imp().search_toggle_button.set_sensitive(true);
+        //} else {
+        //    log::error!("Vault not initialised!");
+        //}
     }
 
     pub fn refresh(&self, map_is_empty: bool) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -381,6 +381,21 @@ impl ApplicationWindow {
                 obj.refresh_model();
             }
         ));
+
+        self.imp().list_store.connect_notify_local(
+            Some("n-items"),
+            clone!(
+                #[weak(rename_to = obj)]
+                self,
+                move |_, _| {
+                    let has_vaults = obj.imp().list_store.n_items() > 0;
+                    obj.imp().select_toggle_button.set_sensitive(has_vaults);
+                    if !has_vaults {
+                        obj.imp().select_toggle_button.set_active(false);
+                    }
+                }
+            ),
+        );
     }
 
     fn fill_list_store(&self) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -396,15 +396,27 @@ impl ApplicationWindow {
             #[weak(rename_to = obj)]
             self,
             move |_| {
-                for row in obj.imp().list_store.into_iter() {
-                    let vault_row = row.unwrap();
-                    let vault_row = vault_row.downcast_ref::<VaultsPageRow>().unwrap();
-                    if vault_row.selected() {
-                        let vault = vault_row.get_vault();
-                        UserConfigManager::instance().remove_vault(vault.get_uuid());
+                if obj.get_view().unwrap() == "vaults" {
+                    for row in obj.imp().list_store.into_iter() {
+                        let vault_row = row.unwrap();
+                        let vault_row = vault_row.downcast_ref::<VaultsPageRow>().unwrap();
+                        if vault_row.selected() {
+                            let vault = vault_row.get_vault();
+                            UserConfigManager::instance().remove_vault(vault.get_uuid());
+                        }
                     }
+                    obj.refresh_model();
+                } else if obj.get_view().unwrap() == "search" {
+                    for row in obj.imp().search_list_store.into_iter() {
+                        let vault_row = row.unwrap();
+                        let vault_row = vault_row.downcast_ref::<VaultsPageRow>().unwrap();
+                        if vault_row.selected() {
+                            let vault = vault_row.get_vault();
+                            UserConfigManager::instance().remove_vault(vault.get_uuid());
+                        }
+                    }
+                    obj.search();
                 }
-                obj.refresh_model();
             }
         ));
     }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -369,6 +369,22 @@ impl ApplicationWindow {
             )
             .flags(SettingsBindFlags::INVERT_BOOLEAN)
             .build();
+
+        self.imp().remove_button.connect_clicked(clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |_| {
+                for row in obj.imp().list_store.into_iter() {
+                    let vault_row = row.unwrap();
+                    let vault_row = vault_row.downcast_ref::<VaultsPageRow>().unwrap();
+                    if vault_row.selected() {
+                        let vault = vault_row.get_vault();
+                        UserConfigManager::instance().remove_vault(vault.get_uuid());
+                    }
+                }
+                obj.refresh_model();
+            }
+        ));
     }
 
     fn fill_list_store(&self) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -29,7 +29,7 @@ use adw::prelude::AdwDialogExt;
 use adw::subclass::prelude::*;
 use gettextrs::gettext;
 use glib::clone;
-use gtk::gio::ListStore;
+use gtk::gio::{ListStore, SettingsBindFlags};
 use gtk::glib::closure_local;
 use gtk::{self, prelude::*};
 use gtk::{CompositeTemplate, gio, glib};
@@ -70,6 +70,8 @@ mod imp {
         pub search_stack: TemplateChild<gtk::Stack>,
         #[template_child]
         pub add_menu_button: TemplateChild<gtk::MenuButton>,
+        #[template_child]
+        pub select_toggle_button: TemplateChild<gtk::ToggleButton>,
 
         pub list_store: ListStore,
         pub search_list_store: ListStore,
@@ -101,6 +103,7 @@ mod imp {
                 search_results: RefCell::new(0),
                 settings: gio::Settings::new(APP_ID),
                 add_menu_button: TemplateChild::default(),
+                select_toggle_button: TemplateChild::default(),
             }
         }
 
@@ -119,6 +122,7 @@ mod imp {
             self.parent_constructed();
 
             obj.setup_gactions();
+            obj.setup_signals();
         }
     }
 
@@ -336,6 +340,27 @@ impl ApplicationWindow {
                 }
             )
         );
+    }
+
+    fn setup_signals(&self) {
+        self.imp()
+            .settings
+            .bind(
+                "select-vaults",
+                &self.imp().select_toggle_button.get(),
+                "active",
+            )
+            .build();
+
+        self.imp()
+            .settings
+            .bind(
+                "select-vaults",
+                &self.imp().add_menu_button.get(),
+                "visible",
+            )
+            .flags(SettingsBindFlags::INVERT_BOOLEAN)
+            .build();
     }
 
     fn fill_list_store(&self) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -255,14 +255,6 @@ impl ApplicationWindow {
     }
 
     fn setup_vaults_page(&self) {
-        UserConfigManager::instance().connect_add_vault(clone!(
-            #[weak(rename_to = obj)]
-            self,
-            move || {
-                obj.add_vault();
-            }
-        ));
-
         UserConfigManager::instance().connect_refresh(clone!(
             #[weak(rename_to = obj)]
             self,
@@ -427,28 +419,6 @@ impl ApplicationWindow {
         ));
     }
 
-    pub fn add_vault(&self) {
-        // TODO: Updating model
-        let vault = UserConfigManager::instance().get_current_vault();
-
-        if let Some(vault) = vault {
-            let row = VaultsPageRow::new(vault.clone());
-            self.row_connect_remove(&row);
-
-            self.imp().list_store.insert_sorted(&row, |v1, v2| {
-                let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
-                let name1 = row1.get_name();
-                let row2 = v2.downcast_ref::<VaultsPageRow>().unwrap();
-                let name2 = row2.get_name();
-                name1.cmp(&name2)
-            });
-
-            self.imp().search_toggle_button.set_sensitive(true);
-        } else {
-            log::error!("Vault not initialised!");
-        }
-    }
-
     pub fn refresh_view(&self, map_is_empty: bool) {
         if self.imp().search_toggle_button.is_active() {
             return;
@@ -577,6 +547,8 @@ impl ApplicationWindow {
     }
 
     pub fn refresh_model(&self) {
+        log::info!("refresh_model()");
+
         self.clear();
 
         UserConfigManager::instance().read_config();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -124,6 +124,8 @@ mod imp {
             let obj = self.obj();
             self.parent_constructed();
 
+            let _ = self.settings.set_boolean("select-vaults", false);
+
             obj.setup_gactions();
             obj.setup_signals();
         }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -393,14 +393,7 @@ impl ApplicationWindow {
             );
 
             let row = VaultsPageRow::new(vault);
-            self.row_connect_remove(&row);
-            self.bind_property(
-                "is-selected",
-                &row.imp().select_vault_button.get(),
-                "visible",
-            )
-            .sync_create()
-            .build();
+            self.row_connect_signals(&row);
 
             self.imp().list_store.insert_sorted(&row, |v1, v2| {
                 let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -446,7 +439,7 @@ impl ApplicationWindow {
         ));
     }
 
-    pub fn row_connect_remove(&self, row: &VaultsPageRow) {
+    pub fn row_connect_signals(&self, row: &VaultsPageRow) {
         row.connect_remove(clone!(
             #[weak(rename_to = obj)]
             self,
@@ -466,6 +459,14 @@ impl ApplicationWindow {
                 }
             }
         ));
+
+        self.bind_property(
+            "is-selected",
+            &row.imp().select_vault_button.get(),
+            "visible",
+        )
+        .sync_create()
+        .build();
     }
 
     pub fn refresh_view(&self, map_is_empty: bool) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -229,7 +229,7 @@ impl ApplicationWindow {
                 );
 
                 let row = VaultsPageRow::new(vault);
-                self.search_row_connect_remove(&row);
+                self.search_row_connect_signals(&row);
 
                 self.imp().search_list_store.insert_sorted(&row, |v1, v2| {
                     let row1 = v1.downcast_ref::<VaultsPageRow>().unwrap();
@@ -434,7 +434,7 @@ impl ApplicationWindow {
         }
     }
 
-    pub fn search_row_connect_remove(&self, row: &VaultsPageRow) {
+    pub fn search_row_connect_signals(&self, row: &VaultsPageRow) {
         row.connect_remove(clone!(
             #[weak(rename_to = obj)]
             self,
@@ -464,6 +464,14 @@ impl ApplicationWindow {
                 }
             }
         ));
+
+        self.bind_property(
+            "is-selected",
+            &row.imp().select_vault_button.get(),
+            "visible",
+        )
+        .sync_create()
+        .build();
     }
 
     pub fn row_connect_signals(&self, row: &VaultsPageRow) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -505,7 +505,7 @@ impl ApplicationWindow {
                 move |dialog: AddNewVaultWindow| {
                     let vault = dialog.get_vault();
                     let password = dialog.get_password();
-                    match Backend::init(&vault.get_config().unwrap(), password) {
+                    match Backend::init(&vault.config(), password) {
                         Ok(_) => {
                             UserConfigManager::instance().add_vault(vault);
                             obj.set_view(View::Vaults);
@@ -521,7 +521,7 @@ impl ApplicationWindow {
                                     .unwrap()
                                     .clone();
                                 let info_dialog = gtk::AlertDialog::builder()
-                                    .message(vault.get_name().unwrap())
+                                    .message(vault.name())
                                     .detail(format!("{}", e))
                                     .modal(true)
                                     .build();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -215,8 +215,6 @@ impl ApplicationWindow {
                     v.encrypted_data_directory.to_owned(),
                     v.mount_directory.to_owned(),
                     v.session_lock,
-                    v.use_custom_binary,
-                    v.custom_binary_path.clone(),
                 );
 
                 let row = VaultsPageRow::new(vault);
@@ -359,8 +357,6 @@ impl ApplicationWindow {
                 v.encrypted_data_directory.to_owned(),
                 v.mount_directory.to_owned(),
                 v.session_lock,
-                v.use_custom_binary,
-                v.custom_binary_path.clone(),
             );
 
             let row = VaultsPageRow::new(vault);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -268,7 +268,7 @@ impl ApplicationWindow {
             #[weak(rename_to = obj)]
             self,
             move |map_is_empty| {
-                obj.refresh(map_is_empty);
+                obj.refresh_view(map_is_empty);
             }
         ));
 
@@ -469,7 +469,7 @@ impl ApplicationWindow {
         //}
     }
 
-    pub fn refresh(&self, map_is_empty: bool) {
+    pub fn refresh_view(&self, map_is_empty: bool) {
         if self.imp().search_toggle_button.is_active() {
             return;
         }
@@ -508,6 +508,7 @@ impl ApplicationWindow {
                     match Backend::init(&vault.config(), password) {
                         Ok(_) => {
                             UserConfigManager::instance().add_vault(vault);
+                            obj.refresh_model();
                             obj.set_view(View::Vaults);
                         }
                         Err(e) => {
@@ -565,9 +566,8 @@ impl ApplicationWindow {
                 self,
                 move |dialog: ImportVaultDialog| {
                     let vault = dialog.get_vault();
-
                     UserConfigManager::instance().add_vault(vault);
-
+                    obj.refresh_model();
                     obj.set_view(View::Vaults);
                 }
             ),
@@ -593,6 +593,10 @@ impl ApplicationWindow {
     }
 
     pub fn refresh_clicked(&self) {
+        self.refresh_model();
+    }
+
+    pub fn refresh_model(&self) {
         self.clear();
 
         UserConfigManager::instance().read_config();

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,4 +1,4 @@
-// mod.rs
+// user_config.rs
 //
 // Copyright 2025 Martin Pobaschnig
 //
@@ -17,5 +17,3 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pub mod global_config;
-pub mod user_config;

--- a/src/user_config_manager.rs
+++ b/src/user_config_manager.rs
@@ -212,6 +212,7 @@ impl UserConfigManager {
     pub fn add_vault(&self, vault: Vault) {
         log::debug!("Add vault: {:?}, {:?}", &vault.name(), &vault.config());
 
+        #[allow(unused_assignments)]
         let mut is_map_empty = false;
         {
             let map = &mut self.imp().vaults.borrow_mut();
@@ -227,6 +228,7 @@ impl UserConfigManager {
     pub fn remove_vault(self, uuid: Uuid) {
         log::trace!("remove_vault({:?})", &uuid);
 
+        #[allow(unused_assignments)]
         let mut is_map_empty = false;
         {
             let map = &mut self.imp().vaults.borrow_mut();

--- a/src/user_config_manager.rs
+++ b/src/user_config_manager.rs
@@ -202,14 +202,10 @@ impl UserConfigManager {
     }
 
     pub fn add_vault(&self, vault: Vault) {
-        log::debug!(
-            "Add vault: {:?}, {:?}",
-            &vault.get_name().unwrap(),
-            &vault.get_config().unwrap()
-        );
+        log::debug!("Add vault: {:?}, {:?}", &vault.name(), &vault.config());
 
         let map = &mut self.imp().vaults.borrow_mut();
-        map.insert(vault.get_uuid(), vault.get_config().unwrap());
+        map.insert(vault.get_uuid(), vault.config());
         self.write_config(map);
 
         self.emit_by_name::<()>("add-vault", &[]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-// mod.rs
+// uuid.rs
 //
 // Copyright 2025 Martin Pobaschnig
 //
@@ -17,5 +17,23 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pub mod global_config;
-pub mod user_config;
+use crate::user_config_manager::UserConfigManager;
+use uuid::Uuid;
+
+pub fn generate_uuid() -> Uuid {
+    let map = UserConfigManager::instance().get_map();
+    for _ in 0..1000 {
+        let uuid = Uuid::new_v4();
+        if map.contains_key(&uuid) {
+            log::debug!(
+                "Generated UUID {} already exists, generating a new one",
+                uuid
+            );
+            continue;
+        }
+        log::debug!("Generated unique UUID: {}", uuid);
+        return uuid;
+    }
+    log::error!("Failed to generate a unique UUID after 10 attempts");
+    Uuid::nil()
+}

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -244,6 +244,7 @@ mod tests {
     #[test]
     fn check_hidden_paths() {
         let vault = Vault::new(
+            Uuid::nil(),
             "".to_string(),
             Backend::Gocryptfs,
             "".to_string(),

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -33,8 +33,6 @@ pub struct VaultConfig {
     pub encrypted_data_directory: String,
     pub mount_directory: String,
     pub session_lock: Option<bool>,
-    pub use_custom_binary: Option<bool>,
-    pub custom_binary_path: Option<String>,
 }
 
 mod imp {
@@ -68,8 +66,6 @@ impl Vault {
         encrypted_data_directory: String,
         mount_directory: String,
         session_lock: Option<bool>,
-        use_custom_binary: Option<bool>,
-        custom_binary_path: Option<String>,
     ) -> Vault {
         let object: Self = glib::Object::new();
 
@@ -80,8 +76,6 @@ impl Vault {
             encrypted_data_directory,
             mount_directory,
             session_lock,
-            use_custom_binary,
-            custom_binary_path,
         }));
 
         object
@@ -255,8 +249,6 @@ mod tests {
             "".to_string(),
             "".to_string(),
             None,
-            None,
-            None,
         );
         assert!(!vault.is_mount_hidden());
 
@@ -265,8 +257,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: ".".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(!vault.is_mount_hidden());
 
@@ -275,8 +265,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "..".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(!vault.is_mount_hidden());
 
@@ -285,8 +273,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "./".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(!vault.is_mount_hidden());
 
@@ -295,8 +281,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "./Hidden".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(!vault.is_mount_hidden());
 
@@ -305,8 +289,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "Test/.Test".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(vault.is_mount_hidden());
 
@@ -315,8 +297,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "./Test/.Test".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(vault.is_mount_hidden());
 
@@ -325,8 +305,6 @@ mod tests {
             encrypted_data_directory: "".to_string(),
             mount_directory: "../.Test".to_string(),
             session_lock: None,
-            use_custom_binary: None,
-            custom_binary_path: None,
         });
         assert!(vault.is_mount_hidden());
     }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -32,7 +32,7 @@ pub struct VaultConfig {
     pub backend: Backend,
     pub encrypted_data_directory: String,
     pub mount_directory: String,
-    pub session_lock: Option<bool>,
+    pub session_lock: bool,
 }
 
 mod imp {
@@ -65,7 +65,7 @@ impl Vault {
         backend: Backend,
         encrypted_data_directory: String,
         mount_directory: String,
-        session_lock: Option<bool>,
+        session_lock: bool,
     ) -> Vault {
         let object: Self = glib::Object::new();
 
@@ -249,63 +249,70 @@ mod tests {
             Backend::Gocryptfs,
             "".to_string(),
             "".to_string(),
-            None,
+            false,
         );
         assert!(!vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: ".".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(!vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "..".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(!vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "./".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(!vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "./Hidden".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(!vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "Test/.Test".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "./Test/.Test".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(vault.is_mount_hidden());
 
         vault.set_config(VaultConfig {
+            name: "".to_string(),
             backend: Backend::Gocryptfs,
             encrypted_data_directory: "".to_string(),
             mount_directory: "../.Test".to_string(),
-            session_lock: None,
+            session_lock: false,
         });
         assert!(vault.is_mount_hidden());
     }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -17,10 +17,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{
-    backend::{Backend, BackendError},
-    util,
-};
+use crate::backend::{Backend, BackendError};
 use gio::VolumeMonitor;
 use gio::prelude::*;
 use gio::subclass::prelude::*;
@@ -43,7 +40,7 @@ pub struct VaultConfig {
 mod imp {
     use super::*;
 
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Debug, Deserialize, Serialize, Default)]
     pub struct Vault {
         pub uuid: RefCell<Uuid>,
         pub config: RefCell<Option<VaultConfig>>,
@@ -54,22 +51,6 @@ mod imp {
         const NAME: &'static str = "Vault";
         type ParentType = glib::Object;
         type Type = super::Vault;
-
-        fn new() -> Self {
-            Self {
-                uuid: RefCell::new(Uuid::nil()),
-                config: RefCell::new(None),
-            }
-        }
-    }
-
-    impl Default for Vault {
-        fn default() -> Self {
-            Vault {
-                uuid: RefCell::new(util::generate_uuid()),
-                config: RefCell::new(None),
-            }
-        }
     }
 
     impl ObjectImpl for Vault {}

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -209,7 +209,7 @@ impl Vault {
         let encrypted_data_directory = self.encrypted_data_directory();
         let path = std::path::Path::new(&encrypted_data_directory);
         log::debug!("Deleting encrypted data directory: {:?}", path);
-        return std::fs::remove_dir_all(path);
+        std::fs::remove_dir_all(path)
     }
 }
 


### PR DESCRIPTION
This is a series of commits that change how we handle user configs, vaults, and states. Each vault now gets a UUID internally so we are no longer limited to the name being unique. We are also moving from explicit to implicit saving of the states and configs. Additionally, the UI and internal state handling is overhauled.